### PR TITLE
Amendments on copyright for 0003: Guidelines on Licensing and DCO

### DIFF
--- a/assets/LICENSE
+++ b/assets/LICENSE
@@ -1,4 +1,4 @@
-<project> is Copyright © 2019-2020 Monadic GmbH <company@monadic.xyz>
+<project> is Copyright © <year> The <project> Contributors
 
 <project> is licensed under version 3 of the GNU General Public
 License (GPLv3) with the Radicle Linking Exception. Any contribution to

--- a/assets/LICENSE-MIT
+++ b/assets/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Monadic GmbH <company@monadic.xyz>
+Copyright (c) <year> The <project> Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/assets/license-header-rustfmt-template
+++ b/assets/license-header-rustfmt-template
@@ -1,4 +1,4 @@
-// <project> is Copyright © {[-,0-9]+} {.+}
+// <project> is Copyright © {[-,0-9 ]+} {.+}
 //
 // This file is part of <project>, distributed under the GPL v3 with Radicle Linking Exception.
 // For full terms see the included LICENSE file.

--- a/assets/license-header-rustfmt-template
+++ b/assets/license-header-rustfmt-template
@@ -1,0 +1,4 @@
+// <project> is Copyright © {[-,0-9]+} {.+}
+//
+// This file is part of <project>, distributed under the GPL v3 with Radicle Linking Exception.
+// For full terms see the included LICENSE file.

--- a/proposals/0003.md
+++ b/proposals/0003.md
@@ -59,8 +59,12 @@ name of the repository. You MUST replace these with the actual name.
 `Monadic GmbH` is reserved for `radicle-upstream` while `The Radicle Foundation`
 is used for any protocol related repositories.
 
+**Note** that external contributors may add their own name to new or
+_substantially_ modified source code files.
+
 Also included is a [script][license-header-check] for checking the
-license-header for Rust files.
+license-header for Rust files, and a [template][license-header-template] for use
+with the `licence_template_path` directive of `rustfmt`.
 
 ## CONTRIBUTING File
 
@@ -162,5 +166,6 @@ template][pr-template] which has the following checklist:
 [license-file]: ../assets/LICENSE
 [license-header]: ../assets/license-header
 [license-header-check]: ../assets/license-header-check
+[license-header-template]: ../assets/license-header-rustfmt-template
 [mit]: ../assets/LICENSE-MIT
 [pr-template]: https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository


### PR DESCRIPTION
Changes the wording of copyright notices to read "The <project>
Contributors" in LICENSE files, and adds a `rustfmt` header check
template which doesn't require a fixed copyright holder.

Reasoning: in the jurisdictions we're operating in, copyright is not
transferrable. While contributions by employees fall under the copyright
of the employer, this is not true for external contributions: if the
work is copyrightable (ie. "substantial"), they can add their own name
to the license header of the file(s) they created / modified.
