### PR TITLE
Dev friendly headers

### DIFF
--- a/assets/license-header
+++ b/assets/license-header
@@ -1,4 +1,6 @@
-<project> is Copyright © 2019-2020 [The Radicle Foundation <hello@radicle.foundation> OR Monadic GmbH <company@monadic.xyz>].
+<project> is Copyright © <year>
+[The Radicle Foundation <hello@radicle.foundation> OR Monadic GmbH <company@monadic.xyz>].
 
-This file is part of <project>, distributed under the GPL v3 with Radicle Linking Exception.
+This file is part of <project>,
+distributed under the GPL v3 with Radicle Linking Exception.
 For full terms see the included LICENSE file.

--- a/assets/license-headers-check
+++ b/assets/license-headers-check
@@ -1,15 +1,44 @@
 #!/usr/bin/env bash
 #
-# Iterates over all rust source files and ensures they start with the license
-# header as per the `.license-header` file at the root of the repository.
+# Iterates over all source files and ensures they start with the license.
+# If run with the `--fix` option license headers are added if they are missing.
 
 set -euo pipefail
-IFS=$'\n'
-
 shopt -s globstar extglob
-for file in */+(src|tests|examples)/**/*.rs
-do
-    rustfmt --config license_template_path=".license-header" --color never --quiet --check "$file" || {
-        sed -i -e '1r.license-header' -e '1{h;d}' -e '2{x;G}' "$file"
-    }
+
+# CONFIGURE THE FOLLOWING VARIABLES BEFORE USAGE
+project_name="<project>"
+contributors_default="The Radicle Foundation <hello@radicle.foundation>"
+# OR
+contributors_default="Monadic GmbH <company@monadic.xyz>"
+files='@(src|tests|examples)/**/*.rs' # EXAMPLE GLOB FOR A RUST PROJECT
+
+template="\
+// $project_name is Copyright © %s
+// %s
+//
+// This file is part of $project_name,
+// distributed under the GPL v3 with Radicle Linking Exception.
+// For full terms see the included LICENSE file
+"
+pattern=$(printf "$template*" '+([-, 0-9])' '?*')
+
+for file in $files; do
+    body=$(<"$file")
+    if [[ "$body" = $pattern ]]; then
+        continue
+    fi
+    if [[ "${1:-}" != "--fix" ]]; then
+        echo "License header missing for $file."
+        echo "Rerun with --fix to add license header."
+        exit 1
+    fi
+    if [ ! "${contributors:-}" ]; then
+        echo "Enter contributor name and contact to use when" \
+            "adding the missing headers [$contributors_default]: "
+        read contributors
+        contributors=${contributors:-$contributors_default}
+    fi
+    echo "Adding license header to $file"
+    printf "$template\n%s\n" "$(date +%Y)" "$contributors" "$body" > "$file"
 done

--- a/proposals/0003.md
+++ b/proposals/0003.md
@@ -51,16 +51,19 @@ Every repository MUST include a `DCO` which corresponds to this
 
 Every file that contains source code MUST include a header which corresponds to
 this [file][license-header] at the **top** of each source file as a comment.
+The header needs to be adjusted for a specific repository:
 
-**Note** that there are placeholders `<project>` which correspond to the
+- there are placeholders `<project>` which correspond to the
 name of the repository. You MUST replace these with the actual name.
 
-**Note** that there is a choice between `The Radicle Foundation` OR `Monadic GmbH`.
+- there is a choice between `The Radicle Foundation` OR `Monadic GmbH`.
 `Monadic GmbH` is reserved for `radicle-upstream` while `The Radicle Foundation`
 is used for any protocol related repositories.
 
-Also included is a [script][license-header-check] for checking the
-license-header for Rust files.
+The header can be applied and verified with a [script][license-header-check].
+It should be run on the CI too to check if all the files have the header.
+The script contains a few variables, which need to be configured
+with values specific for each repository.
 
 ## CONTRIBUTING File
 
@@ -97,6 +100,7 @@ For consistency and clarity, we must include a header at the top of each
 source file. The template for this header can be found
 [here](./path/to/license-header). If you are creating a new file in the
 repository you will have to add this header to the file.
+It can be done to all new files with [the script](./path/to/license-header-check).
 ```
 
 ## DCO Bot
@@ -141,6 +145,21 @@ up by including it a `git commit` alias, for example:
 ```
 # gcs for git-commit-sign-off
 alias gcs="git commit -s"
+```
+
+The other way is to configure git to automatically sign-off every commit.
+This solution works with every tool or alias in the developer's system.
+The following code needs to be added to `.git/hooks/prepare-commit-msg`.
+Please remember to double check if this file is an executable shell script.
+
+```
+NAME="$(git config user.name)"
+: "${NAME:?'empty git config user.name'}"
+EMAIL="$(git config user.email)"
+: "${EMAIL:?'empty git config user.email'}"
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"
 ```
 
 ## Pull Request Template


### PR DESCRIPTION
My 5¢ after applying the licensing rules on the actual code. I hope that it's not too late :grimacing: 

1. Break header's lines to fit in 80 columns, some projects are slim!
2. Add a note about automatic sign-offs. Saves a thing to remember and doesn't break existing scripts and aliases
3. Modify the header checker to include an option to check the correctness of the project, useful in CIs. Based on a script from radicle-registry. Now it uses its own copy of the header, there's no need to litter our repos with hidden files.