### PR TITLE
Amend the merge instructions

### DIFF
--- a/proposals/0003.md
+++ b/proposals/0003.md
@@ -124,7 +124,7 @@ This will be indicated by the green checks in the GitHub UI. Once you are
 satisfied then you can use:
 
 ```
-$ git merge -s --squash
+$ git merge --signoff --squash
 ```
 
 Since this commit could contain several authors it is RECOMMENDED that you do a
@@ -135,6 +135,14 @@ At this point you SHALL add a final sign-off:
 ```
 Signed-off-by: John Doe <john.doe@example.com>
 ```
+
+You can do this by running:
+
+```
+$ git commit -s -v
+```
+
+The `-v` option opens your editor with the message and a diff.
 
 ## Monadic Sign-offs
 


### PR DESCRIPTION
The `-s` option in the instructions was incorrect and instead the option
should be `--signoff`.

We also add the follow-up action `git commit -s -v`.