### PR TITLE
Add Radicle client protocol spec

### DIFF
--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -132,13 +132,6 @@ analoguous to a "GET" request in REST.
 radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo
 ```
 
-- Show a resource identified by `Radicle ID` and pass along metadata. The JSON
-  object to be encoded is: `{name:"fncy",description:"Fancy project"}`.
-
-```
-radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ImZuY3kiLGRlc2NyaXB0aW9uOiJGYW5jeSBwcm9qZWN0In0
-```
-
 
 [community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856
 [deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -1,4 +1,4 @@
-* Title: *Radicle client URI scheme*
+* Title: *Radicle client URL scheme*
 * Champion: *@rudolfs, rudolfs@osins.org*
 * Conversation:
   * [Radicle Community discussion][community]
@@ -17,23 +17,23 @@ here.
 
 We have received multiple feature requests from our community regarding
 deep-linking in our client application. A common way to enable such
-functionality is to devise a URI scheme along with a custom protocol and
+functionality is to devise a URL scheme along with a custom protocol and
 implement a handler which listens for requests of the given protocol in the
 client application.
 
 Given that there might be multiple competing Radicle client implementations and
-to make sure that shared URIs are compatible with as many Radicle client
-implementations as possible we decided to have a specification for our URI
+to make sure that shared URLs are compatible with as many Radicle client
+implementations as possible we decided to have a specification for our URL
 scheme.
 
 
 # Recommendation
 
-In order to not reinvent the wheel our URI scheme is a subset of the
+In order to not reinvent the wheel our URL scheme is a subset of the
 [URL spec][urlspec], with some restrictions to make use in certain
 environments more safe.
 
-The URI scheme to be used by Radicle client applications MUST adhere to the
+The URL scheme to be used by Radicle client applications MUST adhere to the
 following scheme:
 
     radicle://<namespace>/<namespaceSpecificPart>
@@ -59,7 +59,7 @@ it should not be possible to delete a project. However, it is fine to show a
 "Delete Project" dialog where the user first has to explicitly confirm the
 destructive action by clicking a button.
 
-To avoid common shell parameter escaping bugs, the URI scheme SHALL be composed
+To avoid common shell parameter escaping bugs, the URL scheme SHALL be composed
 only of the following characters (regex notation):
 
     [._-:/#a-zA-Z0-9]
@@ -71,7 +71,7 @@ to prevent DDOS attacks and buffer overflow bugs.
 
 ## Namespaces
 
-Namespaces provide a way to partition the URI scheme into multiple
+Namespaces provide a way to partition the URL scheme into multiple
 independently versioned compartments, this allows us to change the scheme
 specification in one namespace while leaving another unchanged.
 

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -29,8 +29,8 @@ scheme.
 
 # Recommendation
 
-In order to not reinvent the wheel our URI scheme is a subset of
-[RFC3986][rfc3986], with some restrictions to make use in certain
+In order to not reinvent the wheel our URI scheme is a subset of the
+[URL spec][urlspec], with some restrictions to make use in certain
 environments more safe.
 
 The URI scheme to be used by Radicle client applications MUST adhere to the
@@ -145,7 +145,7 @@ radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ImZuY3ki
 [community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856
 [deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512
 [rfc2119]: https://tools.ietf.org/html/rfc2119
-[rfc3986]: https://tools.ietf.org/html/rfc3986
 [rfc4648]: https://tools.ietf.org/html/rfc4648#section-5
 [rfc8174]: https://tools.ietf.org/html/rfc8174
 [shareable]: https://github.com/radicle-dev/radicle-upstream/issues/840
+[urlspec]: https://url.spec.whatwg.org

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -59,14 +59,13 @@ it should not be possible to delete a project. However, it is fine to show a
 "Delete Project" dialog where the user first has to explicitly confirm the
 destructive action by clicking a button.
 
-To avoid common shell parameter escaping bugs, the URL scheme SHALL be composed
-only of the following characters (regex notation):
-
-    [._-:/#a-zA-Z0-9]
-
 Furthermore, applications MUST NOT accept URLs longer than 1024 bytes, and
 SHOULD discard subsequent events for 1 second after one was received. This is
 to prevent DDOS attacks and buffer overflow bugs.
+
+Lastly, all characters of the [application/x-www-form-encoded set][percent] are
+to be percent-encoded in path components. We RECOMMEND to avoid them for
+legibility.
 
 
 ## Namespaces
@@ -144,6 +143,7 @@ radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ImZuY3ki
 
 [community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856
 [deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512
+[percent]: https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc4648]: https://tools.ietf.org/html/rfc4648#section-5
 [rfc8174]: https://tools.ietf.org/html/rfc8174

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -115,8 +115,7 @@ Where:
   Zero or more hierarchical sub-resources of `<resource>`.
 
 - `<metadata>`
-  A string of [Base64URL][rfc4648] encoded JSON containing metadata related to
-  the resource specified by `<namespaceSpecificPart>`.
+  Metadata related to the resource specified by `<namespaceSpecificPart>`.
 
 All clients MUST support the `Radicle ID` (aka Radicle URN) `<resource>` type.
 Adding new resource types REQUIRES an amendment of this spec.
@@ -145,7 +144,6 @@ radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ImZuY3ki
 [deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512
 [percent]: https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set
 [rfc2119]: https://tools.ietf.org/html/rfc2119
-[rfc4648]: https://tools.ietf.org/html/rfc4648#section-5
 [rfc8174]: https://tools.ietf.org/html/rfc8174
 [shareable]: https://github.com/radicle-dev/radicle-upstream/issues/840
 [urlspec]: https://url.spec.whatwg.org

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -1,0 +1,153 @@
+* Title: *Radicle client URI scheme*
+* Champion: *@rudolfs, rudolfs@osins.org*
+* Conversation:
+  * [Radicle Community discussion][community]
+  * [Shareable identifier discussion][shareable]
+  * [Deep linking discussion][deeplink]
+* References:
+  * [List of URI schemes][urilist]
+
+# Motivation
+
+We have received multiple feature requests from our community regarding
+deep-linking in our client application. A common way to enable such
+functionality is to devise a URI scheme along with a custom protocol and
+implement a handler which listens for requests on the given protocol in a
+client application.
+
+Given that there might be multiple competing Radicle client implementations and
+to make sure that shared URIs are compatible with as many Radicle client
+implementations as possible we decided to have a specification for our URI
+scheme.
+
+
+# Explanation
+
+The main use case for a custom protocol is to be able to open a Radicle client
+application by clicking on a link on the web in an external browser. The
+Radicle client should be able to recognise what kind of resource is being
+requested and be able to render the request accordingly.
+
+Besides showing resources it might be valuable to perform certain actions on
+said resources. For example a user may be able to start tracking a project by
+clicking a link or initiate a fund transfer to a certain address.
+
+
+# Recommendation
+
+To make implementation easier we want to use existing URI parsing libraries,
+therefore our URI scheme should be parsable according to [RFC 3986][rfc3986].
+
+To make sure our URI scheme is extensible in the future and clients can provide
+backwards compatibility for older links we should have a version identifier in
+the scheme.
+
+The URI scheme to be used by Radicle client applications should adhere to the
+following scheme:
+
+    radicle://[<protocolVersion>/<context>/<entity>?action=<action>]
+
+_Note:_ brackets denote optionality.
+
+Where:
+
+- `radicle:` is the Radicle client protocol name.
+- `<protocolVersion>` is a version number of the Radicle client protocol. This
+  should be the letter `v` followed by a positive integer. The current value
+  is: `v0`.
+- `<context>` is a namespace to distinguish which component of the client
+  application should handle the given request. Supported values:
+  - `link` for code collaboration functionality
+  - `ethereum` for Ethereum functionality
+- `<entity>` can be one of the following, depending on `<context>`:
+  - a `Radicle ID`
+  - an Ethereum address or
+  - an Ethereum transaction.
+- `<action>` is the action that will be performed:
+  - `Radicle ID`s support `show` and `track` actions
+  - Ethereum addresses and transactions support only the `show` action.
+
+
+## Examples
+
+- open the client application
+
+  `radicle://`
+
+- show a `Radicle ID`
+
+  `radicle://v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch?action=show`
+
+- track a `Radicle ID`
+
+  `radicle://v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch?action=track`
+
+- show an Ethereum transaction
+
+  `radicle://v0/ethereum/0xabce994f66d036440fabecb9bf29faeac45aaee3efdd81d38dd493f550c4822b?action=show`
+
+- show an Ethereum wallet or contract address
+
+  `radicle://v0/ethereum/0x5a9f9d53e3f838b3d6f5a6c2c11eb5be665d374c?action=show`
+
+
+## Parsing implementation
+
+In JavaScript environments our custom URI can be parsed via the
+[URL][urlapi] and [URLSearchParams][searchapi] APIs:
+
+
+```javascript
+  const {protocol, pathname, search} = new URL("radicle://v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch?action=show")
+
+  // protocol         → "radicle:"
+  // pathname         → "//v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch"
+  // search           → "?action=show"
+
+  const [protocolVersion, context, entity] = pathname.split("/").slice(2)
+
+  // protocolVersion  → "v0"
+  // context          → "link"
+  // entity           → "rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch"
+
+  const params = new URLSearchParams(search)
+  const action = params.get("action")
+
+  // action           → "show"
+```
+
+
+# Drawbacks
+
+There are certain security implications related to supporting remote control
+via custom protocols that implementers of a Radicle client should be aware of:
+
+  - buffer overruns in parameter handling
+  - remote code execution due to parameter escaping bugs
+  - possible DoS attacks by overwhelming receiving application with requests
+  - on macOS it's hard to implement registering custom protocols in an opt-in
+    manner
+
+
+# Open Questions
+
+1) Should it be possible to pass in additional metadata about a requested
+   `<entity>` via query string parameters?
+
+   We considered this at one point in order for the UI to be able to render a
+   `Radicle ID` as either a Project or a User without querying the network.
+
+
+# Future possibilities
+
+New requirements may be incorporated into this URI specification by
+sequentially incrementing the protocol version number.
+
+
+[community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856
+[deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512
+[rfc3986]: https://tools.ietf.org/html/rfc3986
+[searchapi]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+[shareable]: https://github.com/radicle-dev/radicle-upstream/issues/840
+[urilist]: https://en.wikipedia.org/wiki/List_of_URI_schemes
+[urlapi]: https://developer.mozilla.org/en-US/docs/Web/API/URL

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -45,9 +45,7 @@ the scheme.
 The URI scheme to be used by Radicle client applications should adhere to the
 following scheme:
 
-    radicle://[<protocolVersion>/<context>/<entity>?action=<action>]
-
-_Note:_ brackets denote optionality.
+    radicle://<protocolVersion>/<context>/<entity>?action=<action>
 
 Where:
 
@@ -69,10 +67,6 @@ Where:
 
 
 ## Examples
-
-- open the client application
-
-  `radicle://`
 
 - show a `Radicle ID`
 

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -4,8 +4,15 @@
   * [Radicle Community discussion][community]
   * [Shareable identifier discussion][shareable]
   * [Deep linking discussion][deeplink]
-* References:
-  * [List of URI schemes][urilist]
+  * [Shareable identifier discussion][shareable]
+
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 [RFC2119][rfc2119]
+[RFC8174][rfc8174] when, and only when, they appear in all capitals, as shown
+here.
+
 
 # Motivation
 
@@ -140,8 +147,8 @@ sequentially incrementing the protocol version number.
 
 [community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856
 [deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512
-[rfc3986]: https://tools.ietf.org/html/rfc3986
-[searchapi]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+[rfc2119]: https://tools.ietf.org/html/rfc2119
+[rfc8174]: https://tools.ietf.org/html/rfc8174
 [shareable]: https://github.com/radicle-dev/radicle-upstream/issues/840
 [urilist]: https://en.wikipedia.org/wiki/List_of_URI_schemes
 [urlapi]: https://developer.mozilla.org/en-US/docs/Web/API/URL

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -104,21 +104,22 @@ to the user, no further action is necessary.
 The `<namespaceSpecificPart>` of the `link` namespace MUST adhere to the
 following form:
 
-    radicle://link/v0/<resource>[/<subResources>][#<metadata>]
+    radicle://link/v0/<resource>[/<subResource>][#<metadata>]
 
 Where:
 
 - `<resource>`
   A resource within the `link` namespace.
 
-- `<subResources>`
+- `<subResource>`
   Zero or more hierarchical sub-resources of `<resource>`.
 
 - `<metadata>`
   Metadata related to the resource specified by `<namespaceSpecificPart>`.
 
 All clients MUST support the `Radicle ID` (aka Radicle URN) `<resource>` type.
-Adding new resource types REQUIRES an amendment of this spec.
+Adding a new `<resource>` or `<subResource>` REQUIRES an amendment of this
+spec.
 
 The default action when requesting a resource is to be interpreted as "show"
 analoguous to a "GET" request in REST.

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -54,7 +54,7 @@ For security reasons only non-destructive operations SHALL be triggered by
 deep-links in a client application. Any action that would lead to data being
 changed MUST be first confirmed by the user.
 
-For example, while it is okay to disaplay a project by following a deep-link,
+For example, while it is okay to display a project by following a deep-link,
 it should not be possible to delete a project. However, it is fine to show a
 "Delete Project" dialog where the user first has to explicitly confirm the
 destructive action by clicking a button.

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -97,7 +97,7 @@ compatibility with already published links.
 
 When a client receives a request for a link that is of a  higher version than
 the client supports an informational message about the fact SHOULD be displayed
-to the user.
+to the user, no further action is necessary.
 
 
 #### Version `v0`
@@ -130,12 +130,16 @@ analoguous to a "GET" request in REST.
 
 - Show a resource identified by `Radicle ID`.
 
-    radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo
+```
+radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo
+```
 
 - Show a resource identified by `Radicle ID` and pass along metadata. The JSON
-  object to be encoded is: `{name: "fncy", description: "Fancy project"}`.
+  object to be encoded is: `{name:"fncy",description:"Fancy project"}`.
 
-    radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ICJmbmN5IiwgZGVzY3JpcHRpb246ICJGYW5jeSBwcm9qZWN0In0
+```
+radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ImZuY3kiLGRlc2NyaXB0aW9uOiJGYW5jeSBwcm9qZWN0In0
+```
 
 
 [community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856

--- a/proposals/0004.md
+++ b/proposals/0004.md
@@ -2,7 +2,6 @@
 * Champion: *@rudolfs, rudolfs@osins.org*
 * Conversation:
   * [Radicle Community discussion][community]
-  * [Shareable identifier discussion][shareable]
   * [Deep linking discussion][deeplink]
   * [Shareable identifier discussion][shareable]
 
@@ -14,12 +13,12 @@ document are to be interpreted as described in BCP 14 [RFC2119][rfc2119]
 here.
 
 
-# Motivation
+# Summary
 
 We have received multiple feature requests from our community regarding
 deep-linking in our client application. A common way to enable such
 functionality is to devise a URI scheme along with a custom protocol and
-implement a handler which listens for requests on the given protocol in a
+implement a handler which listens for requests of the given protocol in the
 client application.
 
 Given that there might be multiple competing Radicle client implementations and
@@ -28,127 +27,121 @@ implementations as possible we decided to have a specification for our URI
 scheme.
 
 
-# Explanation
-
-The main use case for a custom protocol is to be able to open a Radicle client
-application by clicking on a link on the web in an external browser. The
-Radicle client should be able to recognise what kind of resource is being
-requested and be able to render the request accordingly.
-
-Besides showing resources it might be valuable to perform certain actions on
-said resources. For example a user may be able to start tracking a project by
-clicking a link or initiate a fund transfer to a certain address.
-
-
 # Recommendation
 
-To make implementation easier we want to use existing URI parsing libraries,
-therefore our URI scheme should be parsable according to [RFC 3986][rfc3986].
+In order to not reinvent the wheel our URI scheme is a subset of
+[RFC3986][rfc3986], with some restrictions to make use in certain
+environments more safe.
 
-To make sure our URI scheme is extensible in the future and clients can provide
-backwards compatibility for older links we should have a version identifier in
-the scheme.
-
-The URI scheme to be used by Radicle client applications should adhere to the
+The URI scheme to be used by Radicle client applications MUST adhere to the
 following scheme:
 
-    radicle://<protocolVersion>/<context>/<entity>?action=<action>
+    radicle://<namespace>/<namespaceSpecificPart>
 
 Where:
 
-- `radicle:` is the Radicle client protocol name.
-- `<protocolVersion>` is a version number of the Radicle client protocol. This
-  should be the letter `v` followed by a positive integer. The current value
-  is: `v0`.
-- `<context>` is a namespace to distinguish which component of the client
-  application should handle the given request. Supported values:
-  - `link` for code collaboration functionality
-  - `ethereum` for Ethereum functionality
-- `<entity>` can be one of the following, depending on `<context>`:
-  - a `Radicle ID`
-  - an Ethereum address or
-  - an Ethereum transaction.
-- `<action>` is the action that will be performed:
-  - `Radicle ID`s support `show` and `track` actions
-  - Ethereum addresses and transactions support only the `show` action.
+- `radicle://`
+  The Radicle client protocol name.
+
+- `<namespace>`
+  A namespace that distinguishes which component of the client
+  application the resource addresses.
+
+- `<namespaceSpecificPart>`
+  Further resource hierarchy and metadata as defined by `<namespace>`.
+
+For security reasons only non-destructive operations SHALL be triggered by
+deep-links in a client application. Any action that would lead to data being
+changed MUST be first confirmed by the user.
+
+For example, while it is okay to disaplay a project by following a deep-link,
+it should not be possible to delete a project. However, it is fine to show a
+"Delete Project" dialog where the user first has to explicitly confirm the
+destructive action by clicking a button.
+
+To avoid common shell parameter escaping bugs, the URI scheme SHALL be composed
+only of the following characters (regex notation):
+
+    [._-:/#a-zA-Z0-9]
+
+Furthermore, applications MUST NOT accept URLs longer than 1024 bytes, and
+SHOULD discard subsequent events for 1 second after one was received. This is
+to prevent DDOS attacks and buffer overflow bugs.
+
+
+## Namespaces
+
+Namespaces provide a way to partition the URI scheme into multiple
+independently versioned compartments, this allows us to change the scheme
+specification in one namespace while leaving another unchanged.
+
+Currently clients MUST support only the `link` namespace. The `ethereum`
+namespace is reserved, but not yet specified. Adding new namespaces and all
+breaking changes to existing namespaces SHALL be documented in this spec and go
+through a peer review before becoming accepted.
+
+The first section of the `<namespaceSpecificPart>` MUST be a version number.
+Versioning namespaces allows us to define rules for how client applications
+should handle backwards and forwards compatibility.
+
+
+### The `link` namespace
+
+The current version of this namespace is `v0`, any breaking modifications to it
+REQUIRE a version increase. The version number is a positive integer and should
+be increased sequentially by 1 and documented in a new section below.
+
+Clients adhering to this spec are REQUIRED to support the latest version only,
+however, they MAY support any number of previous versions to retain backwards
+compatibility with already published links.
+
+When a client receives a request for a link that is of a  higher version than
+the client supports an informational message about the fact SHOULD be displayed
+to the user.
+
+
+#### Version `v0`
+
+The `<namespaceSpecificPart>` of the `link` namespace MUST adhere to the
+following form:
+
+    radicle://link/v0/<resource>[/<subResources>][#<metadata>]
+
+Where:
+
+- `<resource>`
+  A resource within the `link` namespace.
+
+- `<subResources>`
+  Zero or more hierarchical sub-resources of `<resource>`.
+
+- `<metadata>`
+  A string of [Base64URL][rfc4648] encoded JSON containing metadata related to
+  the resource specified by `<namespaceSpecificPart>`.
+
+All clients MUST support the `Radicle ID` (aka Radicle URN) `<resource>` type.
+Adding new resource types REQUIRES an amendment of this spec.
+
+The default action when requesting a resource is to be interpreted as "show"
+analoguous to a "GET" request in REST.
 
 
 ## Examples
 
-- show a `Radicle ID`
+- Show a resource identified by `Radicle ID`.
 
-  `radicle://v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch?action=show`
+    radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo
 
-- track a `Radicle ID`
+- Show a resource identified by `Radicle ID` and pass along metadata. The JSON
+  object to be encoded is: `{name: "fncy", description: "Fancy project"}`.
 
-  `radicle://v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch?action=track`
-
-- show an Ethereum transaction
-
-  `radicle://v0/ethereum/0xabce994f66d036440fabecb9bf29faeac45aaee3efdd81d38dd493f550c4822b?action=show`
-
-- show an Ethereum wallet or contract address
-
-  `radicle://v0/ethereum/0x5a9f9d53e3f838b3d6f5a6c2c11eb5be665d374c?action=show`
-
-
-## Parsing implementation
-
-In JavaScript environments our custom URI can be parsed via the
-[URL][urlapi] and [URLSearchParams][searchapi] APIs:
-
-
-```javascript
-  const {protocol, pathname, search} = new URL("radicle://v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch?action=show")
-
-  // protocol         → "radicle:"
-  // pathname         → "//v0/link/rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch"
-  // search           → "?action=show"
-
-  const [protocolVersion, context, entity] = pathname.split("/").slice(2)
-
-  // protocolVersion  → "v0"
-  // context          → "link"
-  // entity           → "rad:git:hwd1yrebu1gwhx8r5mmruz76nqxehibek6tbxo53jna3qdwyfo6be8y8gch"
-
-  const params = new URLSearchParams(search)
-  const action = params.get("action")
-
-  // action           → "show"
-```
-
-
-# Drawbacks
-
-There are certain security implications related to supporting remote control
-via custom protocols that implementers of a Radicle client should be aware of:
-
-  - buffer overruns in parameter handling
-  - remote code execution due to parameter escaping bugs
-  - possible DoS attacks by overwhelming receiving application with requests
-  - on macOS it's hard to implement registering custom protocols in an opt-in
-    manner
-
-
-# Open Questions
-
-1) Should it be possible to pass in additional metadata about a requested
-   `<entity>` via query string parameters?
-
-   We considered this at one point in order for the UI to be able to render a
-   `Radicle ID` as either a Project or a User without querying the network.
-
-
-# Future possibilities
-
-New requirements may be incorporated into this URI specification by
-sequentially incrementing the protocol version number.
+    radicle://link/v0/rad:git:hnrkdjjrkfmi43ukh594bxtf1k664oo3hzaeo#e25hbWU6ICJmbmN5IiwgZGVzY3JpcHRpb246ICJGYW5jeSBwcm9qZWN0In0
 
 
 [community]: https://radicle.community/t/opening-upstream-via-links-on-the-web/1856
 [deeplink]: https://github.com/radicle-dev/radicle-upstream/issues/1512
 [rfc2119]: https://tools.ietf.org/html/rfc2119
+[rfc3986]: https://tools.ietf.org/html/rfc3986
+[rfc4648]: https://tools.ietf.org/html/rfc4648#section-5
 [rfc8174]: https://tools.ietf.org/html/rfc8174
 [shareable]: https://github.com/radicle-dev/radicle-upstream/issues/840
-[urilist]: https://en.wikipedia.org/wiki/List_of_URI_schemes
-[urlapi]: https://developer.mozilla.org/en-US/docs/Web/API/URL


### PR DESCRIPTION
This adds a proposal for a custom Radicle client protocol spec as discussed [here](https://radicle.community/t/opening-upstream-via-links-on-the-web/1856/8).

[Rendered](https://github.com/radicle-dev/radicle-decisions/blob/61692e0a69385f7077a90f8d52252234906725d8/proposals/0004.md).